### PR TITLE
fix line breaks in plain txt file

### DIFF
--- a/german_stopwords_plain.txt
+++ b/german_stopwords_plain.txt
@@ -247,7 +247,8 @@ hattet
 heraus
 herein
 hier
-hier	hinter
+hier
+hinter
 hiermit
 hiesige
 hin
@@ -486,7 +487,8 @@ unmöglichen
 unmöglicher
 uns
 unser
-unser	unsere
+unser
+unsere
 unsere
 unserem
 unseren


### PR DESCRIPTION
Zwei fehlerhafte Zeilenumbrüche in german_stopwords_plain.txt behoben.